### PR TITLE
Add linkability domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,9 +386,14 @@ The repository includes several examples that demonstrate different aspects of t
 
 3. **BLSAG Linkability** (`examples/blsag_linkability.rs`): Demonstrates the linkable BLSAG variant and how to detect when the same key is used for multiple signatures.
 
-   ```bash
-   cargo run --example blsag_linkability
-   ```
+   - Global linkability:
+     ```bash
+     cargo run --example blsag_linkability
+     ```
+   - Local linkability:
+     ```bash
+     cargo run --example blsag_local_linkability
+     ```
 
 4. **Error Handling** (`examples/error_handling.rs`): Demonstrates proper error handling for common error scenarios.
 

--- a/crates/nostringer/examples/blsag_linkability.rs
+++ b/crates/nostringer/examples/blsag_linkability.rs
@@ -40,10 +40,18 @@ fn main() -> Result<(), Error> {
     println!("   Selected Ring Member {} as the signer", signer_index + 1);
     println!("   Note: Other ring members cannot tell which member is signing!");
 
-    // 3. Sign two different messages with the same key
+    // 3. Create a linkability flag specific to our context (optional)
+    let linkability_flag = Some("blsag_linkability_example".to_string());
+    println!("\n{}", "3. Creating a linkability flag (optional)".bold());
+    println!(
+        "   Linkability flag: {}",
+        linkability_flag.clone().unwrap_or("None".to_string()).bright_blue()
+    );
+
+    // 4. Sign two different messages with the same key
     println!(
         "\n{}",
-        "3. Signing two different messages with the same private key".bold()
+        "4. Signing two different messages with the same private key".bold()
     );
 
     let message1 = b"First vote: Approve proposal A";
@@ -52,8 +60,12 @@ fn main() -> Result<(), Error> {
         std::str::from_utf8(message1).unwrap().green()
     );
 
-    let (signature1, key_image1_hex) =
-        sign_blsag_hex(message1, &signer_keypair.private_key_hex, &ring_pubkeys)?;
+    let (signature1, key_image1_hex) = sign_blsag_hex(
+        message1,
+        &signer_keypair.private_key_hex,
+        &ring_pubkeys,
+        &linkability_flag,
+    )?;
 
     let key_image1 = KeyImage::from_hex(&key_image1_hex)?;
     println!(
@@ -79,8 +91,12 @@ fn main() -> Result<(), Error> {
         std::str::from_utf8(message2).unwrap().green()
     );
 
-    let (signature2, key_image2_hex) =
-        sign_blsag_hex(message2, &signer_keypair.private_key_hex, &ring_pubkeys)?;
+    let (signature2, key_image2_hex) = sign_blsag_hex(
+        message2,
+        &signer_keypair.private_key_hex,
+        &ring_pubkeys,
+        &linkability_flag,
+    )?;
 
     let key_image2 = KeyImage::from_hex(&key_image2_hex)?;
     println!(
@@ -99,10 +115,10 @@ fn main() -> Result<(), Error> {
         }
     );
 
-    // 4. Sign a third message with a different ring member
+    // 5. Sign a third message with a different ring member
     println!(
         "\n{}",
-        "4. Signing a third message with a DIFFERENT private key".bold()
+        "5. Signing a third message with a DIFFERENT private key".bold()
     );
 
     let different_signer_index = 4; // Use a different member
@@ -115,8 +131,12 @@ fn main() -> Result<(), Error> {
     );
     println!("   Signing with Ring Member {}", different_signer_index + 1);
 
-    let (signature3, key_image3_hex) =
-        sign_blsag_hex(message3, &different_signer.private_key_hex, &ring_pubkeys)?;
+    let (signature3, key_image3_hex) = sign_blsag_hex(
+        message3,
+        &different_signer.private_key_hex,
+        &ring_pubkeys,
+        &linkability_flag,
+    )?;
 
     let key_image3 = KeyImage::from_hex(&key_image3_hex)?;
     println!(
@@ -135,10 +155,10 @@ fn main() -> Result<(), Error> {
         }
     );
 
-    // 5. Compare key images to detect same signer
+    // 6. Compare key images to detect same signer
     println!(
         "\n{}",
-        "5. Detecting same signer through key image comparison".bold()
+        "6. Detecting same signer through key image comparison".bold()
     );
 
     let same_key_used_1_2 = key_images_match(&key_image1, &key_image2);

--- a/crates/nostringer/examples/blsag_linkability.rs
+++ b/crates/nostringer/examples/blsag_linkability.rs
@@ -41,12 +41,12 @@ fn main() -> Result<(), Error> {
     println!("   Note: Other ring members cannot tell which member is signing!");
 
     // 3. Create a linkability flag specific to our context (optional)
-    let linkability_flag = Some("blsag_linkability_example".to_string());
-    println!("\n{}", "3. Creating a linkability flag (optional)".bold());
-    println!(
-        "   Linkability flag: {}",
-        linkability_flag.clone().unwrap_or("None".to_string()).bright_blue()
-    );
+    let linkability_flag = None;
+    println!("\n{}", "3. Linkability flag".bold());
+    println!("   In this example, we are using the global linkability. For real-world applications,");
+    println!("   you can create a linkability flag specific to your context.");
+    println!("   (see the blsag_local_linkability.rs example)");
+
 
     // 4. Sign two different messages with the same key
     println!(

--- a/crates/nostringer/examples/blsag_local_linkability.rs
+++ b/crates/nostringer/examples/blsag_local_linkability.rs
@@ -1,0 +1,147 @@
+use colored::Colorize;
+use nostringer::{
+    blsag::{key_images_match, sign_blsag_hex, verify_blsag_hex},
+    generate_keypairs, get_public_keys,
+    types::{Error, KeyImage},
+};
+
+fn main() -> Result<(), Error> {
+    println!(
+        "{}",
+        "NOSTRINGER BLSAG EXAMPLE: Locally Linkable Ring Signatures"
+            .bold()
+            .green()
+    );
+    println!(
+        "{}",
+        "This example demonstrates the impact of different linkability flags for bLSAG.".italic()
+    );
+    println!("{}", "Unlike regular SAG signatures, bLSAG signatures can detect if the same signer created multiple signatures.".italic());
+    println!();
+
+    // 1. Generate a ring of public keys
+    println!("{}", "1. Setting up the ring".bold());
+    let ring_size = 5;
+    println!("   Generating a ring with {} members...", ring_size);
+
+    let keypairs = generate_keypairs(ring_size, "xonly");
+    let ring_pubkeys = get_public_keys(&keypairs);
+
+    // Print the ring members
+    for (i, pubkey) in ring_pubkeys.iter().enumerate() {
+        let shortened = format!("{}...{}", &pubkey[0..8], &pubkey[pubkey.len() - 8..]);
+        println!("   Ring Member {}: {}", i + 1, shortened.cyan());
+    }
+
+    // 2. Choose signer (member 3) for both signatures
+    let signer_index = 2; // 0-based index
+    let signer_keypair = &keypairs[signer_index];
+    println!("\n{}", "2. Selecting a signer".bold());
+    println!("   Selected Ring Member {} as the signer", signer_index + 1);
+    println!("   Note: Other ring members cannot tell which member is signing!");
+
+    // 3. Create a linkability flag specific to our context (optional)
+    let linkability_flag = Some("blsag_local_linkability_example".to_string());
+    println!("\n{}", "3. Creating a linkability flag (optional)".bold());
+    println!(
+        "   Linkability flag: {}",
+        linkability_flag
+            .clone()
+            .unwrap_or("None".to_string())
+            .bright_blue()
+    );
+
+    // 4. Sign two different messages with the same key
+    println!(
+        "\n{}",
+        "4. Signing the same message with the same private key and different linkability flags"
+            .bold()
+    );
+
+    let message = b"Stay safe, Stay anon !";
+    println!(
+        "   Signed message: {}",
+        std::str::from_utf8(message).unwrap().green()
+    );
+
+    let (signature1, key_image1_hex) = sign_blsag_hex(
+        message,
+        &signer_keypair.private_key_hex,
+        &ring_pubkeys,
+        &linkability_flag, // Linkability flag for local linkability
+    )?;
+
+    let key_image1 = KeyImage::from_hex(&key_image1_hex)?;
+    println!(
+        "   Signature 1 created with key image: {}",
+        key_image1_hex[0..16].bright_magenta()
+    );
+
+    // Verify first signature
+    let is_valid1 = verify_blsag_hex(&signature1, &key_image1_hex, message, &ring_pubkeys)?;
+    println!(
+        "   Verification result: {}",
+        if is_valid1 {
+            "Valid ✓".green()
+        } else {
+            "Invalid ✗".red()
+        }
+    );
+
+    // Sign second message
+    let (signature2, key_image2_hex) = sign_blsag_hex(
+        message,
+        &signer_keypair.private_key_hex,
+        &ring_pubkeys,
+        &None, // No linkability flag
+    )?;
+
+    let key_image2 = KeyImage::from_hex(&key_image2_hex)?;
+    println!(
+        "   Signature created with key image: {}",
+        key_image2_hex[0..16].bright_magenta()
+    );
+
+    // Verify second signature
+    let is_valid2 = verify_blsag_hex(&signature2, &key_image2_hex, message, &ring_pubkeys)?;
+    println!(
+        "   Verification result: {}",
+        if is_valid2 {
+            "Valid ✓".green()
+        } else {
+            "Invalid ✗".red()
+        }
+    );
+
+    // 6. Compare key images to detect same signer
+    println!(
+        "\n{}",
+        "6. Detecting same signer through key image comparison".bold()
+    );
+
+    let are_key_images_1_and_2_different = if key_images_match(&key_image1, &key_image2) {
+        "No ✗".red()
+    } else {
+        "Yes ✓".green()
+    };
+    println!(
+        "   Are key images 1 and 2 different? {}",
+        are_key_images_1_and_2_different
+    );
+
+    // Explain the results
+    println!("\n{}", "RESULTS EXPLAINED:".bold());
+    println!("   In bLSAG (Back's Linkable Spontaneous Anonymous Group), each signer produces");
+    println!("   a unique key image derived from their private key. This key image is the same");
+    println!(
+        "   for all signatures produced by the same key, regardless of the message or the ring."
+    );
+    println!("");
+    println!("   This allows detecting when the same key signs multiple messages, without");
+    println!("   revealing which specific key in the ring is the signer.");
+    println!("");
+    println!("   Use cases include preventing double-voting, double-spending, or enforcing");
+    println!("   one-time use credentials, while maintaining anonymity within the group.");
+
+    Ok(())
+}

--- a/crates/nostringer/examples/compact_signatures.rs
+++ b/crates/nostringer/examples/compact_signatures.rs
@@ -3,7 +3,7 @@ use nostringer::{
     sign_compact_blsag,
     sign_compact_sag,
     verify_compact,
-    CompactSignature, // Re-exported from serialization
+    CompactSignature, SignatureVariant, // Re-exported from serialization
 };
 
 fn main() -> Result<(), nostringer::Error> {
@@ -70,6 +70,7 @@ fn main() -> Result<(), nostringer::Error> {
         message2,
         &keypair2.private_key_hex, // Same signer as before
         &ring_pubkeys_hex,
+        &SignatureVariant::Blsag
     )?;
 
     // Display the compact signature

--- a/crates/nostringer/src/blsag.rs
+++ b/crates/nostringer/src/blsag.rs
@@ -27,7 +27,7 @@ pub fn sign_blsag_hex(
         .map(|s| hex_to_point(s))
         .collect::<Result<Vec<_>, _>>()?;
 
-    let flag = linkability_flag.as_ref().map(|s| s.as_bytes()).or_else(|| {
+    let flag = linkability_flag.as_ref().map(|s| s.as_bytes()).or({
         // Default to None if no flag is provided
         None
     });
@@ -215,10 +215,8 @@ pub fn verify_blsag_binary(
     // --- Standard Ring Verification (adapted for bLSAG hashing) ---
     let c0_scalar = signature.c0;
     let r_scalars = &signature.s;
-    let linkability_flag = match &signature.linkability_flag {
-        Some(flag) => Some(flag.as_slice()),
-        None => None,
-    };
+    let linkability_flag = signature.linkability_flag.as_deref();
+
     // Temporary array to store recalculated challenges
     let mut c_recalculated = vec![Scalar::ZERO; ring_size];
 

--- a/crates/nostringer/src/types.rs
+++ b/crates/nostringer/src/types.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use crate::utils::hex_to_point;
 
 /// Defines the type of ring signature to create
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SignatureVariant {
     /// Standard Spontaneous Anonymous Group (SAG) signature
     /// Provides unlinkability (no way to tell if two signatures came from the same signer)
@@ -19,6 +19,12 @@ pub enum SignatureVariant {
     /// Produces a key image that allows detecting when the same key signs multiple times
     /// Still preserves anonymity (doesn't reveal which specific ring member is the signer)
     Blsag,
+
+    /// Back's Linkable Spontaneous Anonymous Group (BLSAG) signature
+    /// Produces a key image that allows detecting when the same key signs multiple times
+    /// with this specific flag
+    /// Still preserves anonymity (doesn't reveal which specific ring member is the signer)
+    BlsagWithFlag(String),
 }
 
 /// Errors that can occur during ring signature operations
@@ -202,6 +208,8 @@ pub struct BlsagSignatureBinary {
     pub c0: Scalar,
     /// Vector of response scalars (s_i).
     pub s: Vec<Scalar>,
+    /// Optional linkability flag to customize the key image to a specific domain.
+    pub linkability_flag: Option<Vec<u8>>,
 }
 
 /// Hex representation of a bLSAG signature (linkable).
@@ -212,6 +220,8 @@ pub struct BlsagSignature {
     pub c0: String,
     /// Vector of response scalars (s_i) encoded as hex.
     pub s: Vec<String>,
+    /// Optional linkability flag to customize the key image to a specific domain.
+    pub linkability_flag: Option<String>,
 }
 
 // --- Conversions for bLSAG Signatures ---
@@ -221,6 +231,16 @@ impl From<&BlsagSignatureBinary> for BlsagSignature {
         BlsagSignature {
             c0: scalar_to_hex(&binary.c0),
             s: binary.s.iter().map(scalar_to_hex).collect(),
+            linkability_flag: match &binary.linkability_flag {
+                Some(flag) => {
+                    // convert Vec<u8> to String
+                    match String::from_utf8(flag.clone()) {
+                        Ok(s) => Some(s),
+                        Err(e) => panic!("Failed to convert linkability flag to String: {}", e),
+                    }
+                }
+                None => None,
+            },
         }
     }
 }
@@ -234,7 +254,16 @@ impl TryFrom<&BlsagSignature> for BlsagSignatureBinary {
             .iter()
             .map(|s_hex| hex_to_scalar(s_hex))
             .collect::<Result<Vec<Scalar>, Error>>()?;
-        Ok(BlsagSignatureBinary { c0, s })
+        let linkability_flag = match &sig.linkability_flag {
+            Some(flag) => Some(flag.as_bytes().to_vec()),
+            None => None,
+        };
+
+        Ok(BlsagSignatureBinary {
+            c0,
+            s,
+            linkability_flag,
+        })
     }
 }
 
@@ -462,6 +491,7 @@ mod tests {
         let binary_sig = BlsagSignatureBinary {
             c0: Scalar::from(4u64),
             s: vec![Scalar::from(5u64), Scalar::from(6u64)],
+            linkability_flag: Some("flag".as_bytes().to_vec()),
         };
 
         let hex_sig: BlsagSignature = (&binary_sig).into();

--- a/crates/nostringer/src/types.rs
+++ b/crates/nostringer/src/types.rs
@@ -254,10 +254,7 @@ impl TryFrom<&BlsagSignature> for BlsagSignatureBinary {
             .iter()
             .map(|s_hex| hex_to_scalar(s_hex))
             .collect::<Result<Vec<Scalar>, Error>>()?;
-        let linkability_flag = match &sig.linkability_flag {
-            Some(flag) => Some(flag.as_bytes().to_vec()),
-            None => None,
-        };
+        let linkability_flag = sig.linkability_flag.as_ref().map(|flag| flag.as_bytes().to_vec());
 
         Ok(BlsagSignatureBinary {
             c0,

--- a/crates/nostringer/tests/integration_test.rs
+++ b/crates/nostringer/tests/integration_test.rs
@@ -231,6 +231,7 @@ fn test_blsag_sign_verify_round_trip() {
     let ring_size = 3;
     let keypairs = generate_keypairs(ring_size, "compressed"); // Use any valid format
     let ring_pubkeys_hex = get_public_keys(&keypairs);
+    let linkability_flag = None; // No linkability needed for this test
 
     // 2. Choose Signer & Message
     let signer_index = 1;
@@ -238,7 +239,12 @@ fn test_blsag_sign_verify_round_trip() {
     let message = b"Test message for bLSAG round trip";
 
     // 3. Sign using bLSAG (hex version)
-    let sign_result = sign_blsag_hex(message, &signer_kp.private_key_hex, &ring_pubkeys_hex);
+    let sign_result = sign_blsag_hex(
+        message,
+        &signer_kp.private_key_hex,
+        &ring_pubkeys_hex,
+        &linkability_flag,
+    );
     assert!(
         sign_result.is_ok(),
         "bLSAG signing failed: {:?}",
@@ -261,17 +267,30 @@ fn test_blsag_sign_verify_round_trip() {
 }
 
 #[test]
-fn test_blsag_linkability() {
+fn test_blsag_global_linkability() {
     // 1. Setup
     let keypairs = generate_keypairs(4, "compressed");
     let ring = get_public_keys(&keypairs);
     let signer_kp = &keypairs[1]; // Choose a signer
     let message1 = b"First message";
     let message2 = b"Second message";
+    let linkability_flag = None; // Enable global linkability
 
     // 2. Sign two different messages with the SAME key
-    let (sig1, ki1_hex) = sign_blsag_hex(message1, &signer_kp.private_key_hex, &ring).unwrap();
-    let (sig2, ki2_hex) = sign_blsag_hex(message2, &signer_kp.private_key_hex, &ring).unwrap();
+    let (sig1, ki1_hex) = sign_blsag_hex(
+        message1,
+        &signer_kp.private_key_hex,
+        &ring,
+        &linkability_flag,
+    )
+    .unwrap();
+    let (sig2, ki2_hex) = sign_blsag_hex(
+        message2,
+        &signer_kp.private_key_hex,
+        &ring,
+        &linkability_flag,
+    )
+    .unwrap();
 
     // 3. Verify both signatures are valid
     assert!(verify_blsag_hex(&sig1, &ki1_hex, message1, &ring).unwrap());
@@ -288,8 +307,75 @@ fn test_blsag_linkability() {
 
     // 5. Sign message 1 with a DIFFERENT key
     let different_signer_kp = &keypairs[2];
-    let (sig3, ki3_hex) =
-        sign_blsag_hex(message1, &different_signer_kp.private_key_hex, &ring).unwrap();
+    let (sig3, ki3_hex) = sign_blsag_hex(
+        message1,
+        &different_signer_kp.private_key_hex,
+        &ring,
+        &linkability_flag,
+    )
+    .unwrap();
+
+    // 6. Verify this signature is also valid
+    assert!(verify_blsag_hex(&sig3, &ki3_hex, message1, &ring).unwrap());
+
+    // 7. Check key images DO NOT MATCH
+    assert_ne!(
+        ki1_hex, ki3_hex,
+        "Key images should differ for different signers"
+    );
+    let ki3 = KeyImage::from_hex(&ki3_hex).unwrap();
+    assert!(!key_images_match(&ki1, &ki3));
+}
+
+
+#[test]
+fn test_blsag_local_linkability() {
+    // 1. Setup
+    let keypairs = generate_keypairs(4, "compressed");
+    let ring = get_public_keys(&keypairs);
+    let signer_kp = &keypairs[1]; // Choose a signer
+    let message1 = b"First message";
+    let message2 = b"Second message";
+    let linkability_flag = Some("Some random flag".to_string()); // Enable local linkability
+
+    // 2. Sign two different messages with the SAME key
+    let (sig1, ki1_hex) = sign_blsag_hex(
+        message1,
+        &signer_kp.private_key_hex,
+        &ring,
+        &linkability_flag,
+    )
+    .unwrap();
+    let (sig2, ki2_hex) = sign_blsag_hex(
+        message2,
+        &signer_kp.private_key_hex,
+        &ring,
+        &linkability_flag,
+    )
+    .unwrap();
+
+    // 3. Verify both signatures are valid
+    assert!(verify_blsag_hex(&sig1, &ki1_hex, message1, &ring).unwrap());
+    assert!(verify_blsag_hex(&sig2, &ki2_hex, message2, &ring).unwrap());
+
+    // 4. Check key images MATCH
+    assert_eq!(
+        ki1_hex, ki2_hex,
+        "Key images should match for the same signer"
+    );
+    let ki1 = KeyImage::from_hex(&ki1_hex).unwrap();
+    let ki2 = KeyImage::from_hex(&ki2_hex).unwrap();
+    assert!(key_images_match(&ki1, &ki2));
+
+    // 5. Sign message 1 with a DIFFERENT key
+    let different_signer_kp = &keypairs[2];
+    let (sig3, ki3_hex) = sign_blsag_hex(
+        message1,
+        &different_signer_kp.private_key_hex,
+        &ring,
+        &linkability_flag,
+    )
+    .unwrap();
 
     // 6. Verify this signature is also valid
     assert!(verify_blsag_hex(&sig3, &ki3_hex, message1, &ring).unwrap());
@@ -309,9 +395,16 @@ fn test_blsag_verification_fail_tampered_message() {
     let ring = get_public_keys(&keypairs);
     let signer_kp = &keypairs[0];
     let message = b"Original BLSAG message";
+    let linkability_flag = None;
 
     // Sign
-    let (sig, ki_hex) = sign_blsag_hex(message, &signer_kp.private_key_hex, &ring).unwrap();
+    let (sig, ki_hex) = sign_blsag_hex(
+        message,
+        &signer_kp.private_key_hex,
+        &ring,
+        &linkability_flag,
+    )
+    .unwrap();
 
     // Verify with tampered message
     let tampered_message = b"Tampered BLSAG message";
@@ -329,13 +422,26 @@ fn test_blsag_verification_fail_wrong_key_image() {
     let ring = get_public_keys(&keypairs);
     let signer_kp = &keypairs[0];
     let message = b"Message for key image test";
+    let linkability_flag = None;
 
     // Sign
-    let (sig, _ki_hex) = sign_blsag_hex(message, &signer_kp.private_key_hex, &ring).unwrap();
+    let (sig, _ki_hex) = sign_blsag_hex(
+        message,
+        &signer_kp.private_key_hex,
+        &ring,
+        &linkability_flag,
+    )
+    .unwrap();
 
     // Generate a key image from a DIFFERENT key
     let different_kp = &keypairs[1];
-    let (_, wrong_ki_hex) = sign_blsag_hex(message, &different_kp.private_key_hex, &ring).unwrap();
+    let (_, wrong_ki_hex) = sign_blsag_hex(
+        message,
+        &different_kp.private_key_hex,
+        &ring,
+        &linkability_flag,
+    )
+    .unwrap();
 
     // Verify with the wrong key image (should fail)
     let is_valid = verify_blsag_hex(&sig, &wrong_ki_hex, message, &ring)
@@ -352,9 +458,16 @@ fn test_blsag_verification_fail_invalid_key_image_format() {
     let ring = get_public_keys(&keypairs);
     let signer_kp = &keypairs[0];
     let message = b"Message for key image test";
+    let linkability_flag = None;
 
     // Sign
-    let (sig, _ki_hex) = sign_blsag_hex(message, &signer_kp.private_key_hex, &ring).unwrap();
+    let (sig, _ki_hex) = sign_blsag_hex(
+        message,
+        &signer_kp.private_key_hex,
+        &ring,
+        &linkability_flag,
+    )
+    .unwrap();
 
     // Verify with an invalid hex string for key image
     let invalid_ki_hex = "invalid-hex-string";


### PR DESCRIPTION
based on https://github.com/AbdelStark/nostringer-rs/issues/25

Allow the signer to customize their key image for a specific context:
-> The signer can now have an (almost) infinite amount of key images
-> Each signature can be customized with a linkability flag to keep external observers to link signatures made on protocol 1 with signatures from protocol 2
-> The flag used to customize the key image to the context can be public and is needed to verify the signature

What have been done here:
- implement a new element in `SignatureVariant`: `BlsagWithFlag(String)` which is the same as a `Blsag`with the String being added into the `hash_to_point` as a salt. 
- added some tests
- added a specific example file for the local linkability: `blsag_local_linkability.rs`